### PR TITLE
Re-enable driveby after menu access and set clock speed for time sync

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -164,6 +164,7 @@ AddEventHandler('cd_easytime:SyncTime', function(data)
 end)
 
 Citizen.CreateThread(function()
+    NetworkOverrideClockMillisecondsPerGameMinute(Config.TimeCycleSpeed*1000)
     while true do
         if self.hours ~= nil and self.mins ~= nil then
             if not PauseSync.state then
@@ -279,6 +280,7 @@ AddEventHandler('cd_easytime:ToggleNUIFocus', function()
     end
     SetNuiFocus(false, false)
     SetNuiFocusKeepInput(false)
+    SetPlayerCanDoDriveBy(PlayerId(), true)
     local count, keys = 0, {177, 200, 202, 322}
     while count < 100 do 
         Wait(0)


### PR DESCRIPTION
1. When accessing the easytime menu, driveby capabilties are taken away from the player. This pull request re-enables driveby capabilies. Driveby capabilties are defined as "shooting from a vehicle".
2. When the clock speed is set low, there is flickering in the clock, because the Network Clock is running at, let's say, 2 seconds by default, but if we want it to be 7 seconds, then it flickers. This pull request tells the client that the clock speed is whatever the time sync is expecting, therefore resulting in smoother time (don't know how to word this really. just that the clock glitches out if you don't do this and you have 7 seconds or higher as the "seconds per minute")