### PR TITLE
Config for Loaf Housing to fix orange tint

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -92,7 +92,11 @@ RegisterNetEvent('cd_easytime:PauseSync')
 AddEventHandler('cd_easytime:PauseSync', function(boolean, time)
     if boolean then
         PauseSync.state = true
-        PauseSync.time = time or 20
+        if Config.LoafHousing then
+            PauseSync.time = time or 12
+        else
+            PauseSync.time = time or 20
+        end
         ChangeWeather('EXTRASUNNY', true)
         ChangeBlackout(self.blackout)
     else

--- a/configs/config.lua
+++ b/configs/config.lua
@@ -62,3 +62,5 @@ Config.WeatherGroups = { --These are the weather groups, it will cycle through e
     [3] = {'SMOG', 'FOGGY'},--foggy
     [4] = {'SNOWLIGHT', 'SNOW', 'BLIZZARD', 'XMAS'},--snow
 }
+
+Config.LoafHousing = true -- If using loaf housing and having issues with orange tint when inside an instance


### PR DESCRIPTION
When using loaf housing the 'cd_easytime:PauseSync' defaults to set the time to 20:00 which sometimes causes an orange tint when in the instanced house. Changing the default time for 'cd_easytime:PauseSync' from 20:00 to 12:00 fixes this.