### PR TITLE
Fix: Separate API calls for real weather and real time when both are enabled  When both Config.Weather.METHOD and Config.Time.METHOD are set to 'real' with different cities, the script incorrectly used the weather city for both weather and time data retrieval. 

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -68,11 +68,15 @@ end
 
 CreateThread(function()
     if Config.Weather.METHOD =='real' and Config.Time.METHOD == 'real' then
-        local real_world_data = GetRealWorldData(Config.Weather.RealWeather.city)
-        self.real_info = real_world_data.info
-        self.weather = real_world_data.weather or 'CLEAR'
-        self.hours = real_world_data.hours or 08
-        self.mins = real_world_data.mins or 00
+        -- Get weather data from weather city
+        local real_weather_data = GetRealWorldData(Config.Weather.RealWeather.city)
+        self.weather = real_weather_data.weather or 'CLEAR'
+        
+        -- Get time data from time city
+        local real_time_data = GetRealWorldData(Config.Time.RealTime.city)
+        self.real_info = real_time_data.info
+        self.hours = real_time_data.hours or 08
+        self.mins = real_time_data.mins or 00
         self.dynamic = false
         self.freeze = false
         self.instantweather = false
@@ -198,7 +202,7 @@ RegisterServerEvent('cd_easytime:ForceUpdate', function(data)
 end)
 
 local function RealWeatherChange()
-    local real_world_data = GetRealWorldData(Config.Time.RealTime.city)
+    local real_world_data = GetRealWorldData(Config.Weather.RealWeather.city)
     self.real_info = real_world_data.info
     if real_world_data.weather ~= self.weather then
         self.weather = real_world_data.weather


### PR DESCRIPTION
## Bug Fix: Incorrect City Usage for Real Weather/Time

### Problem
When using both real weather and real time with different cities configured, the script was incorrectly using the weather city for both weather and time data retrieval.

### Root Cause
1. In the initial setup (`CreateThread`), when both methods are set to 'real', the script was fetching all data from `Config.Weather.RealWeather.city`
2. In `RealWeatherChange()` function, the script was using `Config.Time.RealTime.city` instead of `Config.Weather.RealWeather.city`

### Solution
- Modified the initial setup to make separate API calls for weather and time data using their respective city configurations
- Fixed `RealWeatherChange()` to use the correct weather city configuration
- Maintained backward compatibility for existing configurations

### Testing
Tested with:
- `Config.Weather.RealWeather.city = 'Compton'`
- `Config.Time.RealTime.city = 'Berlin'`

Result: Weather correctly syncs to Compton, time correctly syncs to Berlin.

### Files Changed
- `server/server.lua`