### PR TITLE
fix: 🐛 Fix server-side exploit allowing unauthorized tsunami trigger

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -434,10 +434,17 @@ AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
     end
 end)
 
-RegisterServerEvent('cd_easytime:StartTsunamiCountdown', function(boolean)
-    if not Config.TsunamiWarning.ENABLE then return end
-    self.tsunami = boolean
-    TriggerClientEvent('cd_easytime:StartTsunamiCountdown', -1, boolean)
+AddEventHandler('cd_easytime:StartTsunamiCountdown', function(state)
+    if not Config.TsunamiWarning.ENABLE then
+        return
+    end
+
+    if type(state) ~= 'boolean' then
+        return
+    end
+
+    self.tsunami = state
+    TriggerClientEvent('cd_easytime:StartTsunamiCountdown', -1, state)
 end)
 
 RegisterCommand('ape', function(source, args, rawCommand)


### PR DESCRIPTION
This commit fixes a security exploit where the server-side event cd_easytime:StartTsunamiCountdown could be triggered by clients. The event was registered in a way that allowed cheaters to invoke it directly, enabling them to start tsunami mode without authorization. The fix restricts the event to trusted server-side execution.

(I accidentally deleted the previous pull request)